### PR TITLE
Fix Source.socat_id type: int -> UUID, matching socat's real IDs

### DIFF
--- a/lightcurvedb/models/source.py
+++ b/lightcurvedb/models/source.py
@@ -24,7 +24,7 @@ class SourceMetadata(BaseModel):
     """
 
     cross_matches: list[CrossMatch] = PydanticField(default=[])
-    socat_id: int | None = None
+    socat_id: UUID | None = None
 
 
 class Source(BaseModel):
@@ -33,7 +33,7 @@ class Source(BaseModel):
     """
 
     source_id: UUID = Field(default_factory=uuid7)
-    socat_id: int | None = None
+    socat_id: UUID | None = None
     name: str | None = "No Name"
     ra: float | None
     dec: float | None

--- a/lightcurvedb/storage/parquet/source.py
+++ b/lightcurvedb/storage/parquet/source.py
@@ -9,6 +9,21 @@ from lightcurvedb.models.exceptions import SourceNotFoundException
 from lightcurvedb.storage.prototype.source import ProvidesSourceStorage
 
 
+def _socat_id_to_str(socat_id: UUID | None) -> str | None:
+    """Parquet writers don't natively support UUIDs; store as strings,
+    same as source_id, but preserve None (socat_id is optional)."""
+    return str(socat_id) if socat_id is not None else None
+
+
+def _socat_id_from_value(value) -> UUID | None:
+    """Inverse of _socat_id_to_str -- pandas represents a missing value in
+    an otherwise-string column as NaN (float), not None, so check for that
+    explicitly rather than relying on `value is None`."""
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return None
+    return UUID(value)
+
+
 class PandasSourceStorage(ProvidesSourceStorage):
     def __init__(self, path: Path):
         self.path = path
@@ -38,6 +53,7 @@ class PandasSourceStorage(ProvidesSourceStorage):
         # Parquet writers don't natively support UUIDs.
         # Use strings, they're friendlier (though less compact) than bytes.
         new_table["source_id"] = new_table["source_id"].astype(str)
+        new_table["socat_id"] = new_table["socat_id"].map(_socat_id_to_str)
         new_table.set_index("source_id", inplace=True)
 
         if (table := await self._read_file()) is not None:
@@ -53,6 +69,7 @@ class PandasSourceStorage(ProvidesSourceStorage):
         """
         new_table = pd.DataFrame([s.model_dump() for s in sources])
         new_table["source_id"] = new_table["source_id"].astype(str)
+        new_table["socat_id"] = new_table["socat_id"].map(_socat_id_to_str)
         new_table.set_index("source_id", inplace=True)
 
         if (table := await self._read_file()) is not None:
@@ -76,22 +93,24 @@ class PandasSourceStorage(ProvidesSourceStorage):
 
         data = row.to_dict()
         data["source_id"] = str(source_id)
+        data["socat_id"] = _socat_id_from_value(data.get("socat_id"))
         return Source.model_validate(data)
 
-    async def get_by_socat_id(self, socat_id: int) -> Source:
+    async def get_by_socat_id(self, socat_id: UUID) -> Source:
         """
         Retrieve source details by SoCat ID.
         """
         if (table := await self._read_file()) is None:
             raise SourceNotFoundException("Table not found")
 
-        row = table.loc[table["socat_id"] == socat_id]
+        row = table.loc[table["socat_id"] == _socat_id_to_str(socat_id)]
 
         if row.empty:
             raise SourceNotFoundException(f"Source with SoCat ID {socat_id} not found")
 
         data = row.iloc[0].to_dict()
         data["source_id"] = str(row.index[0])
+        data["socat_id"] = _socat_id_from_value(data.get("socat_id"))
         return Source.model_validate(data)
 
     async def get_all(self) -> list[Source]:
@@ -105,6 +124,7 @@ class PandasSourceStorage(ProvidesSourceStorage):
         for source_id, row in table.iterrows():
             data = row.to_dict()
             data["source_id"] = str(source_id)
+            data["socat_id"] = _socat_id_from_value(data.get("socat_id"))
             sources.append(Source.model_validate(data))
         return sources
 
@@ -142,5 +162,6 @@ class PandasSourceStorage(ProvidesSourceStorage):
         for source_id, row in in_bounds.iterrows():
             data = row.to_dict()
             data["source_id"] = str(source_id)
+            data["socat_id"] = _socat_id_from_value(data.get("socat_id"))
             sources.append(Source.model_validate(data))
         return sources

--- a/lightcurvedb/storage/postgres/schema.py
+++ b/lightcurvedb/storage/postgres/schema.py
@@ -5,7 +5,7 @@ PostgreSQL schema for Flux Measurement Table
 SOURCES_TABLE = """
 CREATE TABLE IF NOT EXISTS sources (
     source_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    socat_id INTEGER UNIQUE,
+    socat_id UUID UNIQUE,
     name TEXT,
     ra DOUBLE PRECISION CHECK (ra IS NULL OR (ra >= -180 AND ra <= 180)),
     dec DOUBLE PRECISION CHECK (dec IS NULL OR (dec >= -90 AND dec <= 90)),

--- a/lightcurvedb/storage/postgres/source.py
+++ b/lightcurvedb/storage/postgres/source.py
@@ -121,7 +121,7 @@ class PostgresSourceStorage(ProvidesSourceStorage, PostgresPoolUser):
 
                 return row
 
-    async def get_by_socat_id(self, socat_id: int) -> Source:
+    async def get_by_socat_id(self, socat_id: UUID) -> Source:
         """
         Get source by SOcat ID.
         """

--- a/lightcurvedb/storage/prototype/source.py
+++ b/lightcurvedb/storage/prototype/source.py
@@ -28,7 +28,7 @@ class ProvidesSourceStorage(Protocol):
         """
         ...
 
-    async def get_by_socat_id(self, socat_id: int) -> Source:
+    async def get_by_socat_id(self, socat_id: UUID) -> Source:
         """
         Retrieve source details by SoCat ID.
         """

--- a/tests/test_integrations/test_socat_parquet.py
+++ b/tests/test_integrations/test_socat_parquet.py
@@ -1,0 +1,57 @@
+"""
+Regression coverage for the socat_id UUID fix (Source.socat_id/get_by_socat_id
+used to be typed `int`, but socat's real source IDs are UUIDs) that doesn't
+depend on Docker/testcontainers.
+
+test_socat.py::test_insert already exercises this same integration, but only
+via the session-scoped `backend` fixture in conftest.py, which unconditionally
+requires the `postgres_database`/`timescale_database` fixtures as function
+arguments regardless of which backend is actually parametrized -- so even the
+"parquet" parametrization fails immediately without a Docker daemon. This
+test builds a Pandas/parquet backend directly, so it can run anywhere.
+"""
+
+import random
+from pathlib import Path
+
+import pytest
+from astropy import units as u
+from astropy.coordinates import ICRS
+from socat.client.mock import Client
+
+from lightcurvedb.integrations.socat import upsert_sources
+from lightcurvedb.storage.parquet.backend import generate_pandas_backend
+
+
+@pytest.mark.asyncio
+async def test_insert_and_round_trip_by_socat_id(tmp_path: Path):
+    backend = await generate_pandas_backend(tmp_path)
+
+    socat_client = Client()
+    socat_client.n = 987654
+
+    def make_source(i):
+        return {
+            "position": ICRS(
+                ra=random.random() * 360.0 * u.deg,
+                dec=(random.random() - 0.5) * 180.0 * u.deg,
+            ),
+            "name": f"Test Source {i}",
+            "flux": random.random() * u.Jy,
+        }
+
+    sources = [make_source(i) for i in range(3)]
+    socat_ids = [socat_client.create_source(**s).source_id for s in sources]
+
+    added, modified = await upsert_sources(client=socat_client, backend=backend.sources)
+    assert added == len(sources)
+    assert modified == 0
+
+    for socat_id in socat_ids:
+        lc_source = await backend.sources.get_by_socat_id(socat_id=socat_id)
+        assert lc_source.socat_id == socat_id
+
+    # Idempotent: re-running with no socat-side changes adds/modifies nothing.
+    added, modified = await upsert_sources(client=socat_client, backend=backend.sources)
+    assert added == 0
+    assert modified == 0


### PR DESCRIPTION
socat's source IDs have been UUIDs for as long as this repo's own integrations/socat.py has existed (get_box_fixed() returns RegisteredFixedSource.source_id: uuid.UUID, and upsert_sources() already passes that straight through to backend.get_by_socat_id() and Source(socat_id=...)) -- but Source.socat_id, SourceMetadata.socat_id, the ProvidesSourceStorage.get_by_socat_id Protocol, the Postgres sources.socat_id column (INTEGER UNIQUE), and the Postgres/parquet storage implementations were all still typed/declared as int. Any real socat crossmatch (a UUID) hitting this path would fail: Postgres would reject the UUID value for an integer column, and the parquet backend's `table["socat_id"] == socat_id` comparison would never match after an int-typed column got created from UUID objects.

Fixed end to end: models/source.py, storage/prototype/source.py (Protocol), storage/postgres/{schema,source}.py, and storage/parquet/source.py (which additionally needed the same str-round-trip treatment already given to source_id, since parquet has no native UUID type -- with explicit None-handling, since socat_id is optional and pandas represents a missing value in an otherwise-string column as NaN, not None).

tests/test_integrations/test_socat.py::test_insert already exercised this exact path with real UUIDs (via socat.client.mock.Client), but only through the session-scoped `backend` fixture, which requires Docker/testcontainers for every parametrization including "parquet" (the shared `postgres_database`/`timescale_database` fixtures are unconditional function arguments, and setup_test_data is autouse=True, so no test in this suite can currently run without Docker). Verified the fix with an equivalent standalone script directly against generate_pandas_backend() (no Docker), confirming create -> upsert -> get_by_socat_id round-trips correctly by UUID equality, and that a second upsert_sources() call is idempotent. Also added tests/test_integrations/test_socat_parquet.py, which exercises the same path by building a Pandas backend directly rather than going through the Docker-gated `backend` fixture -- it will run standalone once Docker is available (e.g. in CI), even though this sandboxed environment couldn't execute it directly (the autouse setup_test_data fixture still pulls in the Docker-gated `backend` fixture for every test in this directory regardless of what an individual test declares).